### PR TITLE
Fetch commit before resetting

### DIFF
--- a/build-binaryen.sh
+++ b/build-binaryen.sh
@@ -25,7 +25,9 @@ if [ ! -d $BINARYEN_SRC/ ]; then
 
     # This is the last tested commit of binaryen.
     # Feel free to try with a newer version
-    git reset --hard 8ab8e40d15a4d9f28ced76d28232f9e791f161d3
+    COMMIT=8ab8e40d15a4d9f28ced76d28232f9e791f161d3
+    git fetch origin $COMMIT
+    git reset --hard $COMMIT
 
     git submodule init
     git submodule update

--- a/build-brotli.sh
+++ b/build-brotli.sh
@@ -25,7 +25,9 @@ if [ ! -d $BROTLI_SRC/ ]; then
     
     # This is the last tested commit of brotli.
     # Feel free to try with a newer version
-    git reset --hard 62662f87cdd96deda90ac817de94e3c4af75226a
+    COMMIT=62662f87cdd96deda90ac817de94e3c4af75226a
+    git fetch origin $COMMIT
+    git reset --hard $COMMIT
 
     popd
 fi

--- a/build-cpython.sh
+++ b/build-cpython.sh
@@ -26,7 +26,9 @@ if [ ! -d $CPYTHON_SRC/ ]; then
 
     # This is the last tested commit of cpython.
     # Feel free to try with a newer version
-    git reset --hard b8a9f13abb61bd91a368e2d3f339de736863050f
+    COMMIT=b8a9f13abb61bd91a368e2d3f339de736863050f
+    git fetch origin $COMMIT
+    git reset --hard $COMMIT
 
     popd
 fi

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -26,7 +26,9 @@ if [ ! -d $LLVM_SRC/ ]; then
     
     # This is the last tested commit of llvm-project.
     # Feel free to try with a newer version
-    git reset --hard d5a963ab8b40fcf7a99acd834e5f10a1a30cc2e5
+    COMMIT=d5a963ab8b40fcf7a99acd834e5f10a1a30cc2e5
+    git fetch origin $COMMIT
+    git reset --hard $COMMIT
 
     # The clang driver will sometimes spawn a new process to avoid memory leaks.
     # Since this complicates matters quite a lot for us, just disable that.


### PR DESCRIPTION
PR #14 limits the number of commits cloned, but this can lead to build failures (e.g., Issue #16) if new commits are pushed to the various project repositories.  Before resetting to a specific commit ID, `git fetch` is performed to ensure that sufficient commit history is available in the local repositories.