### PR TITLE
Add CI action to build WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Build
+        run: |
+          ./build-with-docker.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: |
+            ./build/llvm/bin/llvm-box.wasm
+            ./build/llvm/bin/llvm-box.mjs
+          retention-days: 7
+
+  release:
+    needs: build
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.*
+      - name: Setup npmrc
+        run: |
+          echo "@jprendes:registry=https://npm.pkg.github.com/" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}" >> .npmrc
+      - name: Publish
+        run: npm publish

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+.github
+box_src
+build
+demo
+docker
+emlib
+packs
+patches
+quicknode
+src
+tooling
+upstream
+.gitignore
+*.sh
+node_modules
+yarn.lock

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -12,7 +12,7 @@ popd
 mkdir -p $(pwd)/build/emsdk_cache
 
 docker run \
-    -it --rm \
+    -i --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd):$(pwd) \
     -v $(pwd)/build/emsdk_cache:/emsdk/upstream/emscripten/cache \

--- a/llvm-box.d.mts
+++ b/llvm-box.d.mts
@@ -1,0 +1,5 @@
+interface FsModule extends EmscriptenModule {
+    FS: typeof FS;
+}
+
+export default Module as EmscriptenModuleFactory<FsModule>;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@jprendes/emception",
+  "version": "1.0.0",
+  "author": "jprendes",
+  "license": "MIT",
+  "main": "dist/llvm-box.mjs",
+  "type": "module",
+  "types": "llvm-box.d.mts",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "dependencies": {
+    "@types/emscripten": "^1.39.8"
+  }
+}


### PR DESCRIPTION
This PR should add a GitHub action which builds the llvm WASM file (about 2 hours).

If triggered using a tag, a package should also be published onto the GitHub npm registry with emscripten types to allow the WASM file to be imported by another project e.g.:

```typescript
import LlvmBoxModule from '@jprendes/emception';
...
async #init(LlvmBoxModule, FS, opts) {
...

```

This was developed to separate our usage of llvm-box from a consuming project. Feel free to use it as inspiration if something else is required in this project