### PR TITLE
CI: Increase swap space to avoid OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Create swap space
+        shell: bash
+        run: |
+            sudo fallocate -l 15G /swapfile_new
+            sudo chmod 600 /swapfile_new
+            sudo mkswap /swapfile_new
+            sudo swapon /swapfile_new
+            sudo swapon --show
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Build


### PR DESCRIPTION
Github action seems out of memory, causing compilation to abort:

```bash
2023-12-23T06:53:42.4386009Z em++: error: 'tools/clang/lib/AST/CMakeFiles/obj.clangAST.dir/Interp/Disasm.cpp.o' failed (received SIGKILL (-9))
2023-12-23T06:53:42.4428220Z ninja: build stopped: subcommand failed.
2023-12-23T06:53:43.5446445Z ##[error]Process completed with exit code 1.
```

The patch adds swap space to CI and has been tested within my own repo. I'm not sure if we need to make any further changes to the build script or CI to make it abort when an error occurs, rather than silently continuing the build process?
