### PR TITLE
llvm-box: change the argv taken by llvm-box main entry

### DIFF
--- a/box_src/llvm-box.cpp
+++ b/box_src/llvm-box.cpp
@@ -4,15 +4,18 @@
 #include "llvm-box-define-gen.hpp"
 
 int main(int argc, const char ** argv) {
-    if (argc < 1) return 1;
-    
-    const char * argv0 = argv[0];
+    if (argc < 2) {
+        fprintf(stderr, "usage: llvm-box [COMMAND] [ARGUMENTS...]\n");
+        return 1;
+    }
+
+    const char * argv0 = argv[1];
 
     --argc;
     ++argv;
 
     #include "llvm-box-entry-gen.hpp"
-    
+
     fprintf(stderr, "LLVM command \"%s\" not found", argv0);
 
     return 1;


### PR DESCRIPTION
#27 

It looks like llvm-box currently takes the first argument, `argv[0]`, as the command. I'm not sure if this is intentional or if it's just a bug. In most environments, we would probably use it this way:

```bash
llvm-box clang main.cpp
```

In this case, `argv[1]` is `clang`, which is the command we really want. For most operating systems, as well as emscripten's `callMain` method, `llvm-box` is automatically added as `argv[0]`. So I'm not sure if the way it's currently written is intentional or not? It looks like we have to explicitly call the `_main` function and construct a sequence of arguments like this `clang main.cpp`

